### PR TITLE
Docs (.github/auto_assign.yml): Create auto-add reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,10 @@
+reviewers:
+  - magali-la
+  - nkabembo
+  - CMolinaBetancourt
+  
+addReviewers: true
+
+numberOfReviewers: 2
+
+addReviewersSkipAuthors: true


### PR DESCRIPTION
## 🎯Type of Change (Select one or more):

**Docs** 📚: auto-add reviewers

### This PR...

Adds the GitHub action to auto-add reviewers.

---

## 📝 What I Did (Detailed Work):

* Created the file auto_assign.yml in the .github folder.
* Added our GitHub users.
* Set the number of reviewers to 2.
*  Added a rule to skip assigning the author as a reviewer.

---

## 🧪 How to Test (Steps to Verify):

The workflow file is currently missing. Once both files are present, we can test in a PR to see if the reviewers are being assigned automatically.

---

## 🤔 What I learned (gotchas):

I haven't set up this kind of automation before, and it's a great option, it helps ensure you don't forget to add reviewers.
