### PR TITLE
Docs (.github/workflows/auto-assign.yml): configure auto-assignment f…

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,19 @@
+name: Auto Assign PR Reviewers
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto_assign_reviewers:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      pull-requests: write
+      
+    steps:
+      - name: Auto Assign Reviewers (using custom config)
+        uses: kentaro-m/auto-assign-action@v2.0.0 
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: '.github/auto_assign.yml'


### PR DESCRIPTION
## 🎯Type of Change:

**Docs** 📚:  Workflow to auto-assign reviewers to Pull Requests.

### This PR...

Adds the GitHub Actions workflow to automatically assign reviewers to Pull Requests.

---

## 📝 What I Did (Detailed Work):

* Created the GitHub Workflow file (.github/workflows/auto-assign.yml) to trigger the auto-assignment action on pull_request: opened and ready_for_review events.

---

## 🧪 How to Test (Steps to Verify):

1. Create a new branch in your local repository.
2. Open a new Pull Request from that new branch to the main branch (or la rama donde se requiere la revisión).
3. Navigate to the Reviewers section.
4. Verify that the GitHub Action has automatically assigned two of the team members.

---

## 🤔 What I learned (gotchas):

I haven't set up this kind of automation before, and it's a great option, it helps ensure you don't forget to add reviewers.
