### PR TITLE
Added Horizontal padding for mobile view on profile page , added scro…

### DIFF
--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -11,7 +11,7 @@ function Profile() {
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
   let inputClassName =
-    'rounded-none border-0 border-b border-eerie bg-transparent focus:border-stone-600 focus:ring-0';
+    'rounded-none border-0 border-b border-eerie bg-transparent focus:border-stone-600 focus:ring-0 overflow-x-auto';
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
@@ -34,7 +34,7 @@ function Profile() {
   };
   if (loading) return <p>Loading</p>;
   return (
-    <section className="bg-white flex flex-col items-center min-h-[calc(100vh-80px)]">
+    <section className="bg-white flex flex-col items-center min-h-[calc(100vh-80px)] px-8">
       <form className="w-full max-w-md min-w-[60%] flex flex-col">
         <h3 className="text-2xl font-playfair mb-[24px] mt-[60px] place-self-center">
           Profile


### PR DESCRIPTION

* **Style** 🎨: Code formatting or aesthetic changes (CSS).


### This PR...
This PR adds padding to profile page in mobile view and scrolling on input on profile page so text is still visible in mobile view

## 📝 What I Did (Detailed Work):


* Added padding to mobile view
* Noticed onboarding concerns input text was not properly visible so added overflow for horizontal scrolling to be possible to view text

## 🧪 How to Test (Steps to Verify):

1.  Navigate to /profile page locally or on netlify
2.  Open inspector to test changes in mobile view

---

## 🤔 What I learned (gotchas):

I learned more concretely (since I always had confusions around this) ,that sm in tailwind goes from a certain mobile breakpoint to higher , it does not cover all mobile screens to cover mobile screens sm is not needed
